### PR TITLE
Add live language selector on homepage

### DIFF
--- a/src/homepage.cpp
+++ b/src/homepage.cpp
@@ -3,8 +3,10 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QFont>
+#include <QLabel>
 #include <QScrollArea>
 #include <QPainterPath>
+#include <QSignalBlocker>
 #include <QtMath>
 
 // ============================================================
@@ -193,6 +195,22 @@ QFrame *Homepage::createCard() {
     return card;
 }
 
+void Homepage::setCurrentLanguage(const QString &language) {
+    const QString normalized = (language == "en" || language == "ru") ? language : "system";
+    const int index = languageCombo_->findData(normalized);
+    if (index >= 0) {
+        QSignalBlocker blocker(languageCombo_);
+        languageCombo_->setCurrentIndex(index);
+    }
+}
+
+void Homepage::populateLanguageCombo() {
+    languageCombo_->clear();
+    languageCombo_->addItem(tr("System"), "system");
+    languageCombo_->addItem(tr("English"), "en");
+    languageCombo_->addItem(tr("Russian"), "ru");
+}
+
 void Homepage::setupUi() {
     auto *outerLayout = new QVBoxLayout(this);
     outerLayout->setContentsMargins(0, 0, 0, 0);
@@ -212,18 +230,40 @@ void Homepage::setupUi() {
     mainLayout->setSpacing(16);
     mainLayout->setContentsMargins(24, 24, 24, 24);
 
-    // Title
+    auto *headerLayout = new QHBoxLayout;
+    headerLayout->setSpacing(12);
+
+    auto *titleBox = new QVBoxLayout;
+    titleBox->setSpacing(2);
+
     auto *titleLabel = new QLabel(tr("PANORAMA"));
     QFont titleFont = titleLabel->font();
     titleFont.setPointSize(22);
     titleFont.setBold(true);
     titleLabel->setFont(titleFont);
     titleLabel->setStyleSheet("color: #fff; background: transparent;");
-    mainLayout->addWidget(titleLabel);
+    titleBox->addWidget(titleLabel);
 
     auto *subtitleLabel = new QLabel(tr("System Monitoring Dashboard"));
     subtitleLabel->setStyleSheet("color: #666; font-size: 12px; background: transparent; margin-bottom: 4px;");
-    mainLayout->addWidget(subtitleLabel);
+    titleBox->addWidget(subtitleLabel);
+
+    headerLayout->addLayout(titleBox);
+    headerLayout->addStretch();
+
+    auto *languageLabel = new QLabel(tr("Language:"));
+    languageLabel->setStyleSheet("color: #aaa; background: transparent; font-size: 12px;");
+    headerLayout->addWidget(languageLabel);
+
+    languageCombo_ = new QComboBox;
+    languageCombo_->setMinimumWidth(120);
+    populateLanguageCombo();
+    connect(languageCombo_, &QComboBox::currentIndexChanged, this, [this](int) {
+        emit languageChanged(languageCombo_->currentData().toString());
+    });
+    headerLayout->addWidget(languageCombo_);
+
+    mainLayout->addLayout(headerLayout);
 
     // Cards grid: 2 rows x 3 columns conceptually
     // Network spans rows 0-1, col 0

--- a/src/homepage.h
+++ b/src/homepage.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QLabel>
+#include <QComboBox>
 #include <QTimer>
 #include <QFrame>
 #include <QVBoxLayout>
@@ -46,15 +47,22 @@ class Homepage : public QWidget {
 public:
     explicit Homepage(QWidget *parent = nullptr);
 
+    void setCurrentLanguage(const QString &language);
+
+signals:
+    void languageChanged(const QString &language);
+
 private slots:
     void onMetricsUpdated(const SystemMetrics &metrics);
 
 private:
     void setupUi();
     QFrame *createCard();
+    void populateLanguageCombo();
 
     SystemMonitor *monitor_;
     QTimer *updateTimer_;
+    QComboBox *languageCombo_;
 
     // CPU card
     QLabel *cpuUsageLabel_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,15 @@ QString configuredLanguage() {
     return QString::fromStdString(config->language);
 }
 
-void installTranslator(QApplication &app, QTranslator &translator) {
-    const QString language = configuredLanguage();
+void saveLanguage(const QString &language) {
+    panorama::Config config = panorama::ConfigManager::load_config().value_or(panorama::Config{});
+    config.language = (language == "en" || language == "ru") ? language.toStdString() : "system";
+    panorama::ConfigManager::save_config(config);
+}
+
+void applyLanguage(QApplication &app, QTranslator &translator, const QString &language) {
+    app.removeTranslator(&translator);
+
     if (language == "en") {
         return;
     }
@@ -75,7 +82,8 @@ int main(int argc, char *argv[]) {
     app.setDesktopFileName("tryx-panorama-manager");
 
     QTranslator translator;
-    installTranslator(app, translator);
+    QString activeLanguage = configuredLanguage();
+    applyLanguage(app, translator, activeLanguage);
 
     const QString socketPath = instanceSocketPath();
     if (notifyRunningInstance(socketPath)) {
@@ -89,7 +97,13 @@ int main(int argc, char *argv[]) {
                    << instanceServer.errorString();
     }
 
-    MainWindow window;
+    auto languageHandler = [&](const QString &language) {
+        activeLanguage = (language == "en" || language == "ru") ? language : "system";
+        saveLanguage(activeLanguage);
+        applyLanguage(app, translator, activeLanguage);
+    };
+
+    MainWindow window(activeLanguage, languageHandler);
     window.show();
 
     QObject::connect(&instanceServer, &QLocalServer::newConnection, &window, [&]() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,9 +11,17 @@
 #include <QStatusBar>
 #include <QApplication>
 #include <QMessageBox>
+#include <QTimer>
+#include <utility>
 
-MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent) {
+MainWindow::MainWindow(const QString &currentLanguage,
+                       std::function<void(const QString &)> languageHandler,
+                       QWidget *parent)
+    : QMainWindow(parent),
+      languageHandler_(std::move(languageHandler)),
+      currentLanguage_((currentLanguage == "en" || currentLanguage == "ru")
+                           ? currentLanguage
+                           : "system") {
 
     deviceMgr_ = new DeviceManager(this);
     trayMgr_ = new TrayManager(this);
@@ -75,6 +83,7 @@ void MainWindow::setupUi() {
     // Pages
     stack_ = new QStackedWidget;
     homepage_ = new Homepage;
+    homepage_->setCurrentLanguage(currentLanguage_);
     panoramaPage_ = new PanoramaPage(deviceMgr_);
     settingsPage_ = new SettingsPage(deviceMgr_);
 
@@ -157,14 +166,7 @@ void MainWindow::setupConnections() {
 
     connect(deviceMgr_, &DeviceManager::brightnessChanged, trayMgr_, &TrayManager::setBrightnessValue);
 
-    // Panorama page status
-    connect(panoramaPage_, &PanoramaPage::statusMessage, statusBar(),
-            [this](const QString &msg) { statusBar()->showMessage(msg, 5000); });
-    connect(panoramaPage_, &PanoramaPage::metricsRunningChanged, trayMgr_, &TrayManager::setMetricsRunning);
-
-    // Settings page status
-    connect(settingsPage_, &SettingsPage::statusMessage, statusBar(),
-            [this](const QString &msg) { statusBar()->showMessage(msg, 5000); });
+    setupPageConnections();
 
     // Tray actions
     connect(trayMgr_, &TrayManager::showWindowRequested, this, [this]() {
@@ -187,6 +189,51 @@ void MainWindow::setupConnections() {
             panoramaPage_->startMetrics();
         }
     });
+}
+
+void MainWindow::setupPageConnections() {
+    connect(homepage_, &Homepage::languageChanged, this, &MainWindow::onLanguageChanged);
+
+    // Panorama page status
+    connect(panoramaPage_, &PanoramaPage::statusMessage, statusBar(),
+            [this](const QString &msg) { statusBar()->showMessage(msg, 5000); });
+    connect(panoramaPage_, &PanoramaPage::metricsRunningChanged, trayMgr_, &TrayManager::setMetricsRunning);
+
+    // Settings page status
+    connect(settingsPage_, &SettingsPage::statusMessage, statusBar(),
+            [this](const QString &msg) { statusBar()->showMessage(msg, 5000); });
+}
+
+void MainWindow::rebuildCentralUi() {
+    const int currentRow = navList_ ? navList_->currentRow() : 0;
+    if (statusLabel_) {
+        statusBar()->removeWidget(statusLabel_);
+        delete statusLabel_;
+        statusLabel_ = nullptr;
+    }
+
+    setupUi();
+    setupPageConnections();
+
+    if (navList_->count() > 0) {
+        navList_->setCurrentRow(qBound(0, currentRow, navList_->count() - 1));
+    }
+
+    statusLabel_->setText(deviceMgr_->isConnected() ? tr("Connected") : tr("Disconnected"));
+}
+
+void MainWindow::onLanguageChanged(const QString &language) {
+    const QString normalized = (language == "en" || language == "ru") ? language : "system";
+    if (normalized == currentLanguage_) {
+        return;
+    }
+
+    currentLanguage_ = normalized;
+    if (languageHandler_) {
+        languageHandler_(currentLanguage_);
+    }
+
+    QTimer::singleShot(0, this, &MainWindow::rebuildCentralUi);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,6 +4,8 @@
 #include <QStackedWidget>
 #include <QListWidget>
 #include <QLabel>
+#include <QString>
+#include <functional>
 
 class DeviceManager;
 class Homepage;
@@ -14,7 +16,9 @@ class TrayManager;
 class MainWindow : public QMainWindow {
     Q_OBJECT
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(const QString &currentLanguage,
+                        std::function<void(const QString &)> languageHandler,
+                        QWidget *parent = nullptr);
     ~MainWindow();
 
 protected:
@@ -23,16 +27,21 @@ protected:
 private:
     void setupUi();
     void setupConnections();
+    void setupPageConnections();
+    void rebuildCentralUi();
+    void onLanguageChanged(const QString &language);
 
-    DeviceManager *deviceMgr_;
-    Homepage *homepage_;
-    PanoramaPage *panoramaPage_;
-    SettingsPage *settingsPage_;
-    TrayManager *trayMgr_;
+    DeviceManager *deviceMgr_ = nullptr;
+    Homepage *homepage_ = nullptr;
+    PanoramaPage *panoramaPage_ = nullptr;
+    SettingsPage *settingsPage_ = nullptr;
+    TrayManager *trayMgr_ = nullptr;
 
-    QStackedWidget *stack_;
-    QListWidget *navList_;
-    QLabel *statusLabel_;
+    QStackedWidget *stack_ = nullptr;
+    QListWidget *navList_ = nullptr;
+    QLabel *statusLabel_ = nullptr;
+    std::function<void(const QString &)> languageHandler_;
+    QString currentLanguage_;
 
     bool minimizeToTray_ = true;
 };

--- a/src/settingspage.cpp
+++ b/src/settingspage.cpp
@@ -62,25 +62,6 @@ void SettingsPage::setupUi() {
 
     mainLayout->addWidget(behaviorGroup);
 
-    // Language
-    auto *languageGroup = new QGroupBox(tr("Language"));
-    auto *languageLayout = new QGridLayout(languageGroup);
-
-    languageButton_ = new QToolButton;
-    languageButton_->setToolButtonStyle(Qt::ToolButtonTextOnly);
-    languageButton_->setMinimumWidth(96);
-    languageButton_->setToolTip(tr("Switch interface language"));
-    setSelectedLanguage("system");
-
-    languageLayout->addWidget(new QLabel(tr("Interface language:")), 0, 0);
-    languageLayout->addWidget(languageButton_, 0, 1);
-
-    mainLayout->addWidget(languageGroup);
-
-    connect(languageButton_, &QToolButton::clicked, this, [this]() {
-        setSelectedLanguage(nextLanguage(selectedLanguage_));
-    });
-
     // Device info
     auto *infoGroup = new QGroupBox(tr("Device"));
     auto *infoLayout = new QHBoxLayout(infoGroup);
@@ -118,9 +99,6 @@ void SettingsPage::loadSettings() {
             portCombo_->setCurrentText(QString::fromStdString(config->port));
         }
         keepaliveSpin_->setValue(config->keepalive_interval);
-        loadedLanguage_ = QString::fromStdString(config->language);
-        setSelectedLanguage(loadedLanguage_);
-        loadedLanguage_ = selectedLanguage_;
     }
 }
 
@@ -141,35 +119,6 @@ bool SettingsPage::minimizeToTray() const {
 
 bool SettingsPage::startMinimized() const {
     return cbStartMinimized_->isChecked();
-}
-
-QString SettingsPage::selectedLanguage() const {
-    return selectedLanguage_;
-}
-
-QString SettingsPage::languageButtonText(const QString &language) const {
-    if (language == "en") {
-        return tr("EN");
-    }
-    if (language == "ru") {
-        return tr("RU");
-    }
-    return tr("System");
-}
-
-QString SettingsPage::nextLanguage(const QString &language) const {
-    if (language == "system") {
-        return "en";
-    }
-    if (language == "en") {
-        return "ru";
-    }
-    return "system";
-}
-
-void SettingsPage::setSelectedLanguage(const QString &language) {
-    selectedLanguage_ = (language == "en" || language == "ru") ? language : "system";
-    languageButton_->setText(languageButtonText(selectedLanguage_));
 }
 
 void SettingsPage::onRefreshPorts() {
@@ -201,7 +150,6 @@ void SettingsPage::onShowDeviceInfo() {
 void SettingsPage::onResetSettings() {
     portCombo_->setCurrentIndex(0);
     keepaliveSpin_->setValue(10);
-    setSelectedLanguage("system");
     cbMinimizeToTray_->setChecked(true);
     cbStartMinimized_->setChecked(false);
     cbAutostart_->setChecked(false);
@@ -209,11 +157,10 @@ void SettingsPage::onResetSettings() {
 }
 
 void SettingsPage::onSaveSettings() {
-    panorama::Config config;
+    panorama::Config config = panorama::ConfigManager::load_config().value_or(panorama::Config{});
     config.port = selectedPort().toStdString();
     config.keepalive_interval = keepaliveSpin_->value();
     config.brightness = 75;
-    config.language = selectedLanguage().toStdString();
 
     panorama::ConfigManager::save_config(config);
 
@@ -225,10 +172,5 @@ void SettingsPage::onSaveSettings() {
     }
 
     emit settingsChanged();
-    if (selectedLanguage() != loadedLanguage_) {
-        loadedLanguage_ = selectedLanguage();
-        emit statusMessage(tr("Settings saved. Restart the application to apply language changes."));
-    } else {
-        emit statusMessage(tr("Settings saved"));
-    }
+    emit statusMessage(tr("Settings saved"));
 }

--- a/src/settingspage.h
+++ b/src/settingspage.h
@@ -6,7 +6,6 @@
 #include <QCheckBox>
 #include <QPushButton>
 #include <QLabel>
-#include <QToolButton>
 
 class DeviceManager;
 
@@ -33,16 +32,9 @@ private slots:
 private:
     void setupUi();
     void loadSettings();
-    QString selectedLanguage() const;
-    QString languageButtonText(const QString &language) const;
-    QString nextLanguage(const QString &language) const;
-    void setSelectedLanguage(const QString &language);
 
     DeviceManager *deviceMgr_;
     QComboBox *portCombo_;
-    QToolButton *languageButton_;
-    QString loadedLanguage_ = "system";
-    QString selectedLanguage_ = "system";
     QSpinBox *keepaliveSpin_;
     QCheckBox *cbMinimizeToTray_;
     QCheckBox *cbStartMinimized_;

--- a/translations/tryx-panorama_ru.ts
+++ b/translations/tryx-panorama_ru.ts
@@ -182,57 +182,77 @@
 <context>
     <name>Homepage</name>
     <message>
-        <location filename="../src/homepage.cpp" line="216"/>
+        <location filename="../src/homepage.cpp" line="209"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../src/homepage.cpp" line="210"/>
+        <source>English</source>
+        <translation>Английский</translation>
+    </message>
+    <message>
+        <location filename="../src/homepage.cpp" line="211"/>
+        <source>Russian</source>
+        <translation>Русский</translation>
+    </message>
+    <message>
+        <location filename="../src/homepage.cpp" line="239"/>
         <source>PANORAMA</source>
         <translation>PANORAMA</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="224"/>
+        <location filename="../src/homepage.cpp" line="247"/>
         <source>System Monitoring Dashboard</source>
         <translation>Панель мониторинга системы</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="246"/>
+        <location filename="../src/homepage.cpp" line="254"/>
+        <source>Language:</source>
+        <translation>Язык:</translation>
+    </message>
+    <message>
+        <location filename="../src/homepage.cpp" line="286"/>
         <source>Network Status</source>
         <translation>Состояние сети</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="261"/>
+        <location filename="../src/homepage.cpp" line="301"/>
         <source>Download: 0 KB/s</source>
         <translation>Загрузка: 0 КБ/с</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="275"/>
+        <location filename="../src/homepage.cpp" line="315"/>
         <source>Upload: 0 KB/s</source>
         <translation>Отдача: 0 КБ/с</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="303"/>
+        <location filename="../src/homepage.cpp" line="343"/>
         <source>CPU Load</source>
         <translation>Загрузка CPU</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="338"/>
+        <location filename="../src/homepage.cpp" line="378"/>
         <source>GPU Load</source>
         <translation>Загрузка GPU</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="373"/>
+        <location filename="../src/homepage.cpp" line="413"/>
         <source>Memory Load</source>
         <translation>Загрузка памяти</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="422"/>
+        <location filename="../src/homepage.cpp" line="462"/>
         <source>Hard disk Load</source>
         <translation>Загрузка диска</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="510"/>
+        <location filename="../src/homepage.cpp" line="550"/>
         <source>Download: %1</source>
         <translation>Загрузка: %1</translation>
     </message>
     <message>
-        <location filename="../src/homepage.cpp" line="511"/>
+        <location filename="../src/homepage.cpp" line="551"/>
         <source>Upload: %1</source>
         <translation>Отдача: %1</translation>
     </message>
@@ -240,47 +260,47 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="24"/>
+        <location filename="../src/mainwindow.cpp" line="32"/>
         <source>TRYX Panorama Manager</source>
         <translation>TRYX Panorama Manager</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="46"/>
+        <location filename="../src/mainwindow.cpp" line="54"/>
         <source>Homepage</source>
         <translation>Главная</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="47"/>
+        <location filename="../src/mainwindow.cpp" line="55"/>
         <source>Panorama</source>
         <translation>Панорама</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="48"/>
+        <location filename="../src/mainwindow.cpp" line="56"/>
         <source>Rota</source>
         <translation>Rota</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="49"/>
+        <location filename="../src/mainwindow.cpp" line="57"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="87"/>
+        <location filename="../src/mainwindow.cpp" line="96"/>
         <source>ROTA</source>
         <translation>ROTA</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="91"/>
+        <location filename="../src/mainwindow.cpp" line="100"/>
         <source>Lighting &amp; Fan Speed Control</source>
         <translation>Управление подсветкой и скоростью вентиляторов</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="97"/>
+        <location filename="../src/mainwindow.cpp" line="106"/>
         <source>In Development</source>
         <translation>В разработке</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="107"/>
+        <location filename="../src/mainwindow.cpp" line="116"/>
         <source>ROTA is the ARGB lighting and fan speed controller for TRYX coolers.
 
 Planned features:
@@ -297,25 +317,31 @@ Planned features:
   - синхронизация ARGB с материнской платой</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="131"/>
-        <location filename="../src/mainwindow.cpp" line="150"/>
+        <location filename="../src/mainwindow.cpp" line="140"/>
+        <location filename="../src/mainwindow.cpp" line="159"/>
+        <location filename="../src/mainwindow.cpp" line="222"/>
         <source>Disconnected</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="140"/>
+        <location filename="../src/mainwindow.cpp" line="149"/>
         <source>Connected: %1 (S/N: %2, FW: %3)</source>
         <translation>Подключено: %1 (S/N: %2, FW: %3)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="143"/>
+        <location filename="../src/mainwindow.cpp" line="152"/>
         <source>Device connected</source>
         <translation>Устройство подключено</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="155"/>
+        <location filename="../src/mainwindow.cpp" line="164"/>
         <source>Error: %1</source>
         <translation>Ошибка: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="222"/>
+        <source>Connected</source>
+        <translation>Подключено</translation>
     </message>
 </context>
 <context>
@@ -710,8 +736,8 @@ Planned features:
     </message>
     <message>
         <location filename="../src/settingspage.cpp" line="30"/>
-        <location filename="../src/settingspage.cpp" line="128"/>
-        <location filename="../src/settingspage.cpp" line="178"/>
+        <location filename="../src/settingspage.cpp" line="106"/>
+        <location filename="../src/settingspage.cpp" line="127"/>
         <source>Auto</source>
         <translation>Автоматически</translation>
     </message>
@@ -757,89 +783,42 @@ Planned features:
     </message>
     <message>
         <location filename="../src/settingspage.cpp" line="66"/>
-        <source>Language</source>
-        <translation>Язык</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="72"/>
-        <source>Switch interface language</source>
-        <translation>Переключить язык интерфейса</translation>
-    </message>
-    <message>
-        <source>System language</source>
-        <translation type="vanished">Системный язык</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Английский</translation>
-    </message>
-    <message>
-        <source>Russian</source>
-        <translation type="vanished">Русский</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="75"/>
-        <source>Interface language:</source>
-        <translation>Язык интерфейса:</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="85"/>
-        <location filename="../src/settingspage.cpp" line="193"/>
+        <location filename="../src/settingspage.cpp" line="142"/>
         <source>Device</source>
         <translation>Устройство</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="88"/>
+        <location filename="../src/settingspage.cpp" line="69"/>
         <source>Device information</source>
         <translation>Информация об устройстве</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="98"/>
+        <location filename="../src/settingspage.cpp" line="79"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="99"/>
+        <location filename="../src/settingspage.cpp" line="80"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="152"/>
-        <source>EN</source>
-        <translation>EN</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="155"/>
-        <source>RU</source>
-        <translation>RU</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="157"/>
-        <source>System</source>
-        <translation>Система</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="193"/>
+        <location filename="../src/settingspage.cpp" line="142"/>
         <source>Device not connected</source>
         <translation>Устройство не подключено</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="198"/>
+        <location filename="../src/settingspage.cpp" line="147"/>
         <source>Requesting device information...</source>
         <translation>Запрос информации об устройстве...</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="208"/>
+        <location filename="../src/settingspage.cpp" line="156"/>
         <source>Settings reset</source>
         <translation>Настройки сброшены</translation>
     </message>
     <message>
-        <location filename="../src/settingspage.cpp" line="230"/>
-        <source>Settings saved. Restart the application to apply language changes.</source>
-        <translation>Настройки сохранены. Перезапустите приложение, чтобы применить язык.</translation>
-    </message>
-    <message>
-        <location filename="../src/settingspage.cpp" line="232"/>
+        <location filename="../src/settingspage.cpp" line="175"/>
         <source>Settings saved</source>
         <translation>Настройки сохранены</translation>
     </message>


### PR DESCRIPTION
## Summary

- Added a language dropdown on the Homepage.
- Language selection is saved to config.json and applied immediately in the running process.
- MainWindow rebuilds central pages after the translator changes so visible UI updates without a manual restart.
- Removed the Settings language control to keep one language entry point.
- Updated Russian translations for the Homepage language selector.