### PR TITLE
Build only current stable Fedora and update project support

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -11,6 +11,10 @@ on:
       - "maintenance/**"
   workflow_dispatch:
   workflow_call:
+    outputs:
+      fedora-version:
+        description: Stable Fedora release used for the RPM
+        value: ${{ jobs.fedora-release.outputs.version }}
 
 permissions:
   contents: read
@@ -23,20 +27,65 @@ env:
   LC_ALL: C.UTF-8
 
 jobs:
+  fedora-release:
+    name: Resolve current Fedora
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      image: ${{ steps.release.outputs.image }}
+    steps:
+      - name: Resolve latest stable Fedora
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_metadata=$(curl --fail --silent --show-error --location \
+            --retry 3 --connect-timeout 15 --max-time 60 \
+            https://fedoraproject.org/releases.json)
+          fedora_version=$(jq -er '
+            if type != "array" then error("Expected Fedora releases array") else . end
+            | [
+                .[]
+                | select(.version | type == "string")
+                | select(.version | test("^[1-9][0-9]*$"))
+                | .version as $version
+                | select(.link | type == "string")
+                | select(.link | startswith(
+                    "https://download.fedoraproject.org/pub/fedora/linux/releases/"
+                    + $version + "/"))
+                | $version | tonumber
+              ]
+            | if length == 0 then error("No stable Fedora release found")
+              else max | tostring end
+          ' <<< "$release_metadata")
+
+          # Resolve once so build and clean-runtime verification share one image.
+          image_tag="registry.fedoraproject.org/fedora:$fedora_version"
+          docker pull "$image_tag"
+          image=$(docker image inspect --format '{{index .RepoDigests 0}}' "$image_tag")
+          if [[ ! "$image" =~ ^registry\.fedoraproject\.org/fedora@sha256:[0-9a-f]{64}$ ]]; then
+            echo "Fedora image did not resolve to an immutable registry digest" >&2
+            exit 1
+          fi
+          actual_version=$(docker run --rm --read-only --network none \
+            --entrypoint /bin/sh "$image" -eu -c \
+            '. /etc/os-release; test "$ID" = fedora; printf "%s\n" "$VERSION_ID"')
+          if [[ "$actual_version" != "$fedora_version" ]]; then
+            echo "Fedora image version $actual_version does not match release $fedora_version" >&2
+            exit 1
+          fi
+          printf 'version=%s\nimage=%s\n' "$fedora_version" "$image" >> "$GITHUB_OUTPUT"
+
   rpm:
-    name: RPM / Fedora ${{ matrix.fedora }}
+    name: RPM / Fedora ${{ needs.fedora-release.outputs.version }}
+    needs: fedora-release
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - fedora: "43"
-            image: registry.fedoraproject.org/fedora@sha256:b1df059ba84f5ed169e245ee8dfd086925a8eba8e502994840cfe17ed75c6079
-          - fedora: "44"
-            image: registry.fedoraproject.org/fedora@sha256:a2383763c3f25bb4fd4f806d5d2d004ca02589c331e5e94235da1289eb7de633
+    env:
+      FEDORA_VERSION: ${{ needs.fedora-release.outputs.version }}
     container:
-      image: ${{ matrix.image }}
+      image: ${{ needs.fedora-release.outputs.image }}
     defaults:
       run:
         shell: bash
@@ -45,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           dnf install -y \
-            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{ matrix.fedora }}.noarch.rpm"
+            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$FEDORA_VERSION.noarch.rpm"
           dnf install -y --allowerasing \
             appstream \
             cpio \
@@ -117,10 +166,10 @@ jobs:
               packaging/rpm/tryx-panorama-manager.spec
 
           rpm_file=$(find "$rpm_topdir/RPMS/x86_64" -maxdepth 1 -type f \
-            -name "tryx-panorama-manager-$version-1.fc${{ matrix.fedora }}.x86_64.rpm" \
+            -name "tryx-panorama-manager-$version-1.fc$FEDORA_VERSION.x86_64.rpm" \
             -print -quit)
           srpm_file=$(find "$rpm_topdir/SRPMS" -maxdepth 1 -type f \
-            -name "tryx-panorama-manager-$version-1.fc${{ matrix.fedora }}.src.rpm" \
+            -name "tryx-panorama-manager-$version-1.fc$FEDORA_VERSION.src.rpm" \
             -print -quit)
           test -n "$rpm_file"
           test -n "$srpm_file"
@@ -144,18 +193,16 @@ jobs:
 
           mkdir -p dist
           install -m 0644 "$rpm_file" "dist/$(basename "$rpm_file")"
-          if [[ "${{ matrix.fedora }}" == "44" ]]; then
-            install -m 0644 \
-              "$rpm_topdir/SOURCES/tryx-panorama-manager-$version.tar.xz" \
-              "dist/tryx-panorama-manager-$version.tar.xz"
-          fi
+          install -m 0644 \
+            "$rpm_topdir/SOURCES/tryx-panorama-manager-$version.tar.xz" \
+            "dist/tryx-panorama-manager-$version.tar.xz"
           echo "file=dist/$(basename "$rpm_file")" >> "$GITHUB_OUTPUT"
 
       - name: Install and smoke-test RPM
         run: |
           set -euo pipefail
           dnf install -y \
-            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{ matrix.fedora }}.noarch.rpm"
+            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$FEDORA_VERSION.noarch.rpm"
           dnf install -y --allowerasing "${{ steps.package.outputs.file }}"
           rpm -V tryx-panorama-manager
           test "$(tryx-panorama-manager --version)" = \
@@ -190,7 +237,7 @@ jobs:
       - name: Upload Fedora package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tryx-rpm-f${{ matrix.fedora }}-${{ github.run_id }}
+          name: tryx-rpm-f${{ env.FEDORA_VERSION }}-${{ github.run_id }}
           path: |
             dist/*.rpm
             dist/*.tar.xz
@@ -496,20 +543,16 @@ jobs:
           retention-days: 7
 
   rpm-runtime-smoke:
-    name: Clean RPM runtime / Fedora ${{ matrix.fedora }}
-    needs: rpm
+    name: Clean RPM runtime / Fedora ${{ needs.fedora-release.outputs.version }}
+    needs:
+      - fedora-release
+      - rpm
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - fedora: "43"
-            image: registry.fedoraproject.org/fedora@sha256:b1df059ba84f5ed169e245ee8dfd086925a8eba8e502994840cfe17ed75c6079
-          - fedora: "44"
-            image: registry.fedoraproject.org/fedora@sha256:a2383763c3f25bb4fd4f806d5d2d004ca02589c331e5e94235da1289eb7de633
+    env:
+      FEDORA_VERSION: ${{ needs.fedora-release.outputs.version }}
     container:
-      image: ${{ matrix.image }}
+      image: ${{ needs.fedora-release.outputs.image }}
     defaults:
       run:
         shell: bash
@@ -517,7 +560,7 @@ jobs:
       - name: Download RPM built in this workflow
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tryx-rpm-f${{ matrix.fedora }}-${{ github.run_id }}
+          name: tryx-rpm-f${{ env.FEDORA_VERSION }}-${{ github.run_id }}
           path: dist
 
       - name: Install only declared runtime dependencies and smoke-test
@@ -526,7 +569,7 @@ jobs:
           rpm_file=$(find dist -maxdepth 1 -type f -name '*.rpm' -print -quit)
           test -n "$rpm_file"
           dnf install -y \
-            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{ matrix.fedora }}.noarch.rpm"
+            "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$FEDORA_VERSION.noarch.rpm"
           dnf install -y --allowerasing "$rpm_file"
           version=$(rpm -q --qf '%{VERSION}' tryx-panorama-manager)
           test "$(tryx-panorama-manager --version)" = \

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -83,10 +83,11 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ needs.verify-release-source.outputs.version }}"
+          fedora_version="${{ needs.build-packages.outputs.fedora-version }}"
 
           mapfile -t rpm_files < <(
             find release-assets -maxdepth 1 -type f \
-              -name "tryx-panorama-manager-$version-1.fc*.x86_64.rpm" |
+              -name "tryx-panorama-manager-$version-1.fc$fedora_version.x86_64.rpm" |
               LC_ALL=C sort
           )
           mapfile -t deb_files < <(
@@ -105,11 +106,11 @@ jobs:
               LC_ALL=C sort
           )
 
-          test "${#rpm_files[@]}" -eq 2
+          test "${#rpm_files[@]}" -eq 1
           test "${#deb_files[@]}" -eq 1
           test "${#arch_files[@]}" -eq 1
           test "${#source_files[@]}" -eq 1
-          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 5
+          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 4
 
           checksum_file="$RUNNER_TEMP/SHA256SUMS"
           (
@@ -118,7 +119,7 @@ jobs:
               LC_ALL=C sort -z |
               xargs -0 sha256sum > "$checksum_file"
           )
-          test "$(wc -l < "$checksum_file")" -eq 5
+          test "$(wc -l < "$checksum_file")" -eq 4
           mv "$checksum_file" release-assets/SHA256SUMS
           (
             cd release-assets
@@ -161,6 +162,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
           RELEASE_VERSION: ${{ needs.verify-release-source.outputs.version }}
+          FEDORA_VERSION: ${{ needs.build-packages.outputs.fedora-version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -172,7 +174,7 @@ jobs:
           notes_file="$RUNNER_TEMP/release-notes.md"
           {
             printf '# TRYX Panorama Manager %s\n\n' "$RELEASE_VERSION"
-            printf 'Native packages for Fedora 43/44, Ubuntu 24.04 and Linux Mint 22, and current Arch Linux.\n\n'
+            printf 'Native packages for Fedora %s, Ubuntu 24.04 and Linux Mint 22, and current Arch Linux.\n\n' "$FEDORA_VERSION"
             printf 'This release is intentionally a draft. Publish it only after the documented hardware smoke tests pass on a physical PASE device.\n'
           } > "$notes_file"
 

--- a/README.md
+++ b/README.md
@@ -447,13 +447,18 @@ also proves that the exact verified replacement copy still exists.
 
 ## Native Linux packages
 
-TRYX Panorama Manager supports Linux only. Native packaging targets Fedora 43
-and 44, Ubuntu 24.04, Linux Mint 22, and current Arch Linux. A binary package
-built for one distribution is not reused on another distribution.
+TRYX Panorama Manager supports Linux only. Native packaging targets the latest
+stable Fedora release, Ubuntu 24.04, Linux Mint 22, and current Arch Linux. A
+binary package built for one distribution is not reused on another distribution.
+
+Each CI run selects the latest stable Fedora release from the
+[official release metadata](https://fedoraproject.org/releases.json) and pins one
+container image digest for both RPM builds and clean runtime checks. Older
+Fedora releases, Beta, and Rawhide are not build targets.
 
 Release assets use these formats:
 
-- RPM `x86_64` for Fedora 43 and Fedora 44
+- RPM `x86_64` for the latest stable Fedora release at build time
 - DEB `amd64` for Ubuntu 24.04 and Linux Mint 22
 - `.pkg.tar.zst` `x86_64` for current Arch Linux
 - `SHA256SUMS` for artifact verification
@@ -467,7 +472,8 @@ Install a downloaded package with the package manager for your distribution:
 ```fish
 # Fedora. Enable RPM Fusion Free first because media conversion requires the
 # full ffmpeg package with the libx264 encoder.
-sudo dnf install --allowerasing ./tryx-panorama-manager-2.3.0-1.fc44.x86_64.rpm
+set tryx_fedora_release (rpm -E %fedora)
+sudo dnf install --allowerasing ./tryx-panorama-manager-2.3.0-1.fc$tryx_fedora_release.x86_64.rpm
 
 # Ubuntu 24.04 or Linux Mint 22
 sudo apt install ./tryx-panorama-manager_2.3.0-1_amd64.deb

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ Project home: [github.com/DXVSI/Tryx-Linux-GUI](https://github.com/DXVSI/Tryx-Li
 
 If TRYX Panorama Manager is useful to you, you can support continued development, protocol compatibility work, and testing on real hardware.
 
-### USDT on TON
+### Gram or USDT on TON
 
 | Detail | Value |
 |--------|-------|
 | TON DNS | `fedora.ton` |
 | Network | `TON Mainnet` |
-| Token | `USD₮ (USDT Jetton)` |
+| Accepted assets | Native Gram (`GRAM`, formerly Toncoin/TON) or `USD₮ (USDT Jetton)` |
 
 **Wallet address**
 
 `UQBO74LeYwNViA9MfdWPqfj4A5SkJ8vTcVG2uZzYzu9LFU-j`
 
 > [!IMPORTANT]
-> Send only USD₮ via TON Mainnet. Before confirming the transaction, verify that your wallet displays USD₮, not native TON. Do not use TRON, Ethereum, BNB Chain, or any other network.
+> Send only native Gram (GRAM) or USD₮ (USDT) via TON Mainnet. Before confirming the transaction, verify the selected asset, network, and destination address. Do not use TRON, Ethereum, BNB Chain, or any other network.
 
 ## Supported and Planned Models
 


### PR DESCRIPTION
## Summary

- Promote these changes through `development` into `production`; the PR contains only two new commits and three changed files.
- Build only the latest stable Fedora release selected from official release metadata. Exclude older releases, Beta, and Rawhide; resolve and verify one immutable image digest for both RPM build and clean-runtime checks.
- Publish one Fedora RPM alongside the DEB, Arch package, and source archive. Keep strict artifact-count and checksum validation, and use the selected Fedora version in release notes.
- Update project support information to accept native Gram (GRAM, formerly Toncoin/TON) or USD₮ on TON Mainnet, preserving the wallet address and TON DNS.

## Verification

- `actionlint` with ShellCheck: passed.
- Offline resolver and release-asset fixtures: 16 scenarios passed, plus shared-version/digest wiring checks.
- `packaging/scripts/check-release-contract.sh`: passed for 2.3.0.
- All 18 README fish blocks parse; donation address and DNS remain unchanged.
- Live official metadata selection returned Fedora 44.
- Independent read-only review found no blocking issues.
- GitHub Actions must pass before merge.

No runtime/device code, release tags, or existing published release assets are changed.